### PR TITLE
Updates to Dockerfile to fix compatibility issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,11 @@ LABEL org.label-schema.license="https://raw.githubusercontent.com/graalvm/fastr/
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.build-date=$BUILD_DATE \
     org.fastr.version="devel" \
-    org.gnur.version="3.3.2" \
+    org.gnur.version="3.4.0" \
     org.label-schema.schema-version="rc1" \
 maintainer="Daniel Nüst <daniel.nuest@uni-muenster.de>"
 
-CMD ["mx R"]
+WORKDIR /tmp/fastr
+ENV PATH=/usr/mx:$PATH
+ENV LANG=en_US.UTF-8
+CMD ["mx", "R"]


### PR DESCRIPTION
- Update docker file `CMD`  to be compatible with docker version 18.03 format and avoid the following errror.
`docker: Error response from daemon: OCI runtime create failed: container_linux.go:348: starting container process caused "exec: \"mx R\": executable file not found in $PATH": unknown.`

- The FastR implementation uses R 3.4.0. 

- Export LANG to use UTF-8 to avoid the following warnings when R is started.
```
> $ docker run --rm -it fastr
> R version 3.4.0 (FastR)
> Copyright (c) 2013-18, Oracle and/or its affiliates
> Copyright (c) 1995-2017, The R Core Team
> Copyright (c) 2017 The R Foundation for Statistical Computing
> Copyright (c) 2012-4 Purdue University
> Copyright (c) 1997-2002, Makoto Matsumoto and Takuji Nishimura
> All rights reserved.
> 
> FastR is free software and comes with ABSOLUTELY NO WARRANTY.
> You are welcome to redistribute it under certain conditions.
> Type 'license()' or 'licence()' for distribution details.
> 
> R is a collaborative project with many contributors.
> Type 'contributors()' for more information.
> 
> Type 'q()' to quit R.
> Setting LC_COLLATE failed, using default
> Setting LC_MONETARY failed, using default
> Setting LC_TIME failed, using default
> Setting LC_MESSAGES failed, using default
> 
```
